### PR TITLE
Add import pluging to .eslintrc file and change error string to 2

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,8 @@
 {
   "plugins": [
     "prettier",
-    "react"
+    "react",
+    "import"
   ],
   "parser": "babel-eslint",
   "parserOptions": {
@@ -22,7 +23,7 @@
     "eqeqeq": "off",
     "function-paren-newline": "off",
     "import/extensions": "error",
-    "import/first": "errors",
+    "import/first": 2,
     "import/no-extraneous-dependencies": "off",
     "import/no-named-as-default": "off",
     "import/prefer-default-export": "off",


### PR DESCRIPTION
Both master and my branch (after merging in master) gave me errors when running lint after yesterday's fix. Adding the import plugin in the .eslintrc file fixed it on my end. Could you pull from feature/help-faqs and run yarn lint to confirm it's working for you too :)