### PR TITLE
Improve pre-commit speed

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -32,6 +32,7 @@
     "jsx-a11y/anchor-is-valid": "off",
     "no-confusing-arrow": "off",
     "no-else-return": "error",
+    "no-return-assign": "off",
     "no-undef": "off", // throw error on graphql queries
     "no-unused-vars": "error",
     "no-use-before-define": "error",
@@ -50,6 +51,7 @@
     "react/no-unused-state": "off",
     "react/prefer-stateless-function": "error",
     "react/require-default-props": 2,
+    "react/sort-comp": 2,
     "semi": "off"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
     "develop": "gatsby develop",
     "format": "prettier --write 'src/**/*.js'",
     "lint": "eslint 'src/**/*.js'",
-    "precommit": "lint-staged && yarn lint --fix && git add -A",
+    "precommit": "lint-staged",
     "test": "yarn run jest",
     "test:watch": "yarn run jest --watch",
     "deploy:ci":
       "gatsby build && now ./public -A ../now.json -e NODE_ENV=production --token $NOW_TOKEN --team=prideinlondon && now alias --token $NOW_TOKEN --team=prideinlondon"
   },
   "lint-staged": {
-    "*.{js,json,css,md}": ["yarn format"]
+    "src/**/*.{js,json,css,md}": ["yarn format", "yarn lint --fix", "git add -A"]
   },
   "devDependencies": {
     "babel-eslint": "^8.2.3",

--- a/package.json
+++ b/package.json
@@ -21,22 +21,22 @@
     "string-hash": "^1.1.3",
     "styled-components": "^3.2.6"
   },
-  "eslintIgnore": [
-    "src/**/*_spec.js"
-  ],
-  "keywords": [
-    "gatsby"
-  ],
+  "eslintIgnore": ["src/**/*_spec.js"],
+  "keywords": ["gatsby"],
   "license": "MIT",
   "scripts": {
     "build": "gatsby build",
     "develop": "gatsby develop",
     "format": "prettier --write 'src/**/*.js'",
     "lint": "eslint 'src/**/*.js'",
-    "precommit": "yarn format && yarn lint --fix && git add -A",
+    "precommit": "lint-staged && yarn lint --fix && git add -A",
     "test": "yarn run jest",
     "test:watch": "yarn run jest --watch",
-    "deploy:ci": "gatsby build && now ./public -A ../now.json -e NODE_ENV=production --token $NOW_TOKEN --team=prideinlondon && now alias --token $NOW_TOKEN --team=prideinlondon"
+    "deploy:ci":
+      "gatsby build && now ./public -A ../now.json -e NODE_ENV=production --token $NOW_TOKEN --team=prideinlondon && now alias --token $NOW_TOKEN --team=prideinlondon"
+  },
+  "lint-staged": {
+    "*.{js,json,css,md}": ["yarn format"]
   },
   "devDependencies": {
     "babel-eslint": "^8.2.3",
@@ -54,7 +54,7 @@
     "husky": "^0.14.3",
     "jest": "^22.4.3",
     "jest-styled-components": "^5.0.1",
-    "lint-staged": "^7.1.0",
+    "lint-staged": "^7.1.2",
     "now": "^11.1.12",
     "prettier": "^1.12.1",
     "prop-types": "^15.6.1",
@@ -63,11 +63,7 @@
     "react-markdown": "^3.3.2"
   },
   "jest": {
-    "testMatch": [
-      "**/?(*_)(spec|test).js"
-    ],
-    "setupFiles": [
-      "./src/configuration/jest.config.js"
-    ]
+    "testMatch": ["**/?(*_)(spec|test).js"],
+    "setupFiles": ["./src/configuration/jest.config.js"]
   }
 }

--- a/src/templates/events/eventDirectionsSection.js
+++ b/src/templates/events/eventDirectionsSection.js
@@ -112,7 +112,7 @@ export class EventDirectionSection extends React.Component {
               Boolean(width && height) &&
               `url(https://maps.googleapis.com/maps/api/staticmap?${querystring.encode(
                 {
-                  center: `${lat}, ${lon}`,
+                  center: `${lat}${','}${lon}`,
                   zoom: 16,
                   size: `${width}x${height}`,
                   scale: 2,

--- a/src/templates/events/eventDirectionsSection.js
+++ b/src/templates/events/eventDirectionsSection.js
@@ -58,6 +58,14 @@ const MapLink = styled.a`
 export class EventDirectionSection extends React.Component {
   state = { width: null, height: null }
 
+  componentDidMount() {
+    this.updateMapSize()
+  }
+
+  componentDidUpdate() {
+    this.updateMapSize()
+  }
+
   updateMapSize = () => {
     if (this.wrapperRef) {
       const rect = this.wrapperRef.getBoundingClientRect()
@@ -71,14 +79,6 @@ export class EventDirectionSection extends React.Component {
         })
       }
     }
-  }
-
-  componentDidMount() {
-    this.updateMapSize()
-  }
-
-  componentDidUpdate() {
-    this.updateMapSize()
   }
 
   render() {
@@ -112,7 +112,7 @@ export class EventDirectionSection extends React.Component {
               Boolean(width && height) &&
               `url(https://maps.googleapis.com/maps/api/staticmap?${querystring.encode(
                 {
-                  center: `${lat},${lon}`,
+                  center: `${lat}, ${lon}`,
                   zoom: 16,
                   size: `${width}x${height}`,
                   scale: 2,

--- a/yarn.lock
+++ b/yarn.lock
@@ -113,6 +113,12 @@
     follow-redirects "^1.2.5"
     is-buffer "^1.1.5"
 
+"@samverschueren/stream-to-observable@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
+  dependencies:
+    any-observable "^0.3.0"
+
 "@types/configstore@^2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@types/configstore/-/configstore-2.1.1.tgz#cd1e8553633ad3185c3f2f239ecff5d2643e92b6"
@@ -319,9 +325,9 @@ ansi@^0.3.0, ansi@~0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/ansi/-/ansi-0.3.1.tgz#0c42d4fb17160d5a9af1e484bace1c66922c1b21"
 
-any-observable@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/any-observable/-/any-observable-0.2.0.tgz#c67870058003579009083f54ac0abafb5c33d242"
+any-observable@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/any-observable/-/any-observable-0.3.0.tgz#af933475e5806a67d0d7df090dd5e8bef65d119b"
 
 any-promise@^0.1.0:
   version "0.1.0"
@@ -2407,14 +2413,13 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cosmiconfig@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-4.0.0.tgz#760391549580bbd2df1e562bc177b13c290972dc"
+cosmiconfig@^5.0.2:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.0.5.tgz#a809e3c2306891ce17ab70359dc8bdf661fe2cd0"
   dependencies:
     is-directory "^0.3.1"
     js-yaml "^3.9.0"
     parse-json "^4.0.0"
-    require-from-string "^2.0.1"
 
 create-ecdh@^4.0.0:
   version "4.0.3"
@@ -5121,11 +5126,11 @@ is-obj@^1.0.0, is-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
 
-is-observable@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/is-observable/-/is-observable-0.2.0.tgz#b361311d83c6e5d726cabf5e250b0237106f5ae2"
+is-observable@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-observable/-/is-observable-1.1.0.tgz#b3e986c8f44de950867cab5403f5a3465005975e"
   dependencies:
-    symbol-observable "^0.2.2"
+    symbol-observable "^1.1.0"
 
 is-odd@^2.0.0:
   version "2.0.0"
@@ -5970,14 +5975,14 @@ linked-list@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/linked-list/-/linked-list-0.1.0.tgz#798b0ff97d1b92a4fd08480f55aea4e9d49d37bf"
 
-lint-staged@^7.1.0:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-7.1.1.tgz#bcdb5de76a6b52db6b2cf83fce62aee95baf7fa0"
+lint-staged@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-7.1.2.tgz#140b13519a0f9c1f227f4a8b7e1321852aeea860"
   dependencies:
     app-root-path "^2.0.1"
     chalk "^2.3.1"
     commander "^2.14.1"
-    cosmiconfig "^4.0.0"
+    cosmiconfig "^5.0.2"
     debug "^3.1.0"
     dedent "^0.7.0"
     execa "^0.9.0"
@@ -5985,7 +5990,7 @@ lint-staged@^7.1.0:
     is-glob "^4.0.0"
     is-windows "^1.0.2"
     jest-validate "^22.4.0"
-    listr "^0.13.0"
+    listr "^0.14.1"
     lodash "^4.17.5"
     log-symbols "^2.2.0"
     micromatch "^3.1.8"
@@ -6024,15 +6029,15 @@ listr-verbose-renderer@^0.4.0:
     date-fns "^1.27.2"
     figures "^1.7.0"
 
-listr@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/listr/-/listr-0.13.0.tgz#20bb0ba30bae660ee84cc0503df4be3d5623887d"
+listr@^0.14.1:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/listr/-/listr-0.14.1.tgz#8a7afa4a7135cee4c921d128e0b7dfc6e522d43d"
   dependencies:
-    chalk "^1.1.3"
+    "@samverschueren/stream-to-observable" "^0.3.0"
     cli-truncate "^0.2.1"
     figures "^1.7.0"
     indent-string "^2.1.0"
-    is-observable "^0.2.0"
+    is-observable "^1.1.0"
     is-promise "^2.1.0"
     is-stream "^1.1.0"
     listr-silent-renderer "^1.1.1"
@@ -6042,8 +6047,7 @@ listr@^0.13.0:
     log-update "^1.0.2"
     ora "^0.2.3"
     p-map "^1.1.1"
-    rxjs "^5.4.2"
-    stream-to-observable "^0.2.0"
+    rxjs "^6.1.0"
     strip-ansi "^3.0.1"
 
 load-json-file@^1.0.0, load-json-file@^1.1.0:
@@ -8699,10 +8703,6 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
 
-require-from-string@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
-
 "require-like@>= 0.1.1":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/require-like/-/require-like-0.1.2.tgz#ad6f30c13becd797010c468afa775c0c0a6b47fa"
@@ -8863,11 +8863,11 @@ rx-lite@*, rx-lite@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
 
-rxjs@^5.4.2:
-  version "5.5.10"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.10.tgz#fde02d7a614f6c8683d0d1957827f492e09db045"
+rxjs@^6.1.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.2.0.tgz#e024d0e180b72756a83c2aaea8f25423751ba978"
   dependencies:
-    symbol-observable "1.0.1"
+    tslib "^1.9.0"
 
 safe-buffer@5.1.1:
   version "5.1.1"
@@ -9478,12 +9478,6 @@ stream-http@^2.3.1, stream-http@^2.7.2:
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
 
-stream-to-observable@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/stream-to-observable/-/stream-to-observable-0.2.0.tgz#59d6ea393d87c2c0ddac10aa0d561bc6ba6f0e10"
-  dependencies:
-    any-observable "^0.2.0"
-
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
@@ -9639,15 +9633,7 @@ svgo@^0.7.0:
     sax "~1.2.1"
     whet.extend "~0.9.9"
 
-symbol-observable@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
-
-symbol-observable@^0.2.2:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-0.2.4.tgz#95a83db26186d6af7e7a18dbd9760a2f86d08f40"
-
-symbol-observable@^1.0.2, symbol-observable@^1.0.3:
+symbol-observable@^1.0.2, symbol-observable@^1.0.3, symbol-observable@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
 
@@ -9890,7 +9876,7 @@ trough@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.2.tgz#7f1663ec55c480139e2de5e486c6aef6cc24a535"
 
-tslib@^1.6.0:
+tslib@^1.6.0, tslib@^1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.1.tgz#a5d1f0532a49221c87755cfcc89ca37197242ba7"
 


### PR DESCRIPTION
Using lint-staged to prevent prettier and eslint from looking at every single .js file when commiting code. 