### PR TITLE
Fix/build setup

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -31,7 +31,7 @@
     "import/prefer-default-export": "off",
     "indent": "off", // in conflict with prettier
     "jsx-a11y/anchor-is-valid": "off",
-    "max-len": 2,
+    "max-len": 0, // in conflict with prettier
     "no-confusing-arrow": "off",
     "no-else-return": "error",
     "no-return-assign": "off",

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
 - '8'
 cache: yarn
 script:
+- yarn lint 
 - yarn test
 after_success:
 - test $TRAVIS_BRANCH = "master" && yarn global add gatsby && yarn deploy:ci

--- a/src/templates/genericContentPage.js
+++ b/src/templates/genericContentPage.js
@@ -54,8 +54,11 @@ const Content = styled(Column)`
 `
 
 const responsiveBannerUrl = url => {
-  const width = Math.min(window.innerWidth, 1440)
+  if (typeof window === 'undefined') {
+    return null
+  }
 
+  const width = Math.min(window.innerWidth, 1440)
   return `${url}?w=${width}`
 }
 


### PR DESCRIPTION
- Fixes an issue preventing production builds. (use of window object in render method)
- Adds `yarn lint` to CI
- Disables `max-len` eslint rule since we have prettier, and prettier doesn't always strictly respect the printWidth option.